### PR TITLE
Avoiding an unnecessary branch

### DIFF
--- a/src/fixture.c
+++ b/src/fixture.c
@@ -215,13 +215,13 @@ static void doit(void) {
   measure(ticks, input_data);
   differentiate(exec_times, ticks); // inplace
 
+  // we compute the percentiles only on the first exec_times data, since this is time-consuming.
   if (percentiles[number_percentiles - 1] == 0) {
     prepare_percentiles(exec_times);
-  } else {
-    update_statistics(exec_times, classes);
-    report();
   }
-
+  update_statistics(exec_times, classes);
+  report();
+  
   free(ticks);
   free(classes);
   free(input_data);


### PR DESCRIPTION
Since if the percentiles aren't ready yet, we can simply prepare them and still run the tests afterwards. This avoids an unnecessary call to the prepare_inputs function (which could possibly take long, yet it's not that much of an optimization since the possibly many next calls will still be called.)

Note that the percentile are computed using the very first exec_times values and as such are not very accurate for the next tests.