### PR TITLE
support gcc in the Makefile & add a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ dut/aesbitsliced/consts_aes128ctr.o \
 dut/aesbitsliced/int128_aes128ctr.o \
 dut/aesbitsliced/stream_aes128ctr.o \
 dut/aesbitsliced/xor_afternm_aes128ctr.o
-CC=clang
+ifeq ($(CXX),g++)
+	CC=gcc
+else ifeq ($(CXX),clang)
+	CC=clang
+endif
 OPTIMIZATION=-O2
 #CFLAGS	= -Weverything -O0 -fsanitize=memory -fno-omit-frame-pointer -g 
 CFLAGS	= $(OPTIMIZATION)

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,7 @@ dut/aesbitsliced/consts_aes128ctr.o \
 dut/aesbitsliced/int128_aes128ctr.o \
 dut/aesbitsliced/stream_aes128ctr.o \
 dut/aesbitsliced/xor_afternm_aes128ctr.o
-ifeq ($(CXX),g++)
-	CC=gcc
-else ifeq ($(CXX),clang)
-	CC=clang
-endif
+# CC=clang
 OPTIMIZATION=-O2
 #CFLAGS	= -Weverything -O0 -fsanitize=memory -fno-omit-frame-pointer -g 
 CFLAGS	= $(OPTIMIZATION)


### PR DESCRIPTION
Currently, the Makefile supports clang by default. While it's easy to switch the CC value to gcc, it would be easier on users if this were done automatically. I added a simple switch in the Makefile to detect the installed compiler and use that. I also added a .gitignore for C (the standard one Github uses).

Hopefully this is useful. If not, no worries :)