### PR TITLE
Make dudect ready for C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Examples
 
 * `dudect_donnabad` Variant with a glaring timing leak.
 
+* For an example on how to use dudect in a C++ code base, see https://github.com/oreparaz/dudect/pull/23 .
+
 Checking your code for constant time
 ------------------------------------
 
@@ -192,6 +194,7 @@ The following people have contributed to `dudect` through code, bug reports, iss
 * matbok
 * RashidAlsuwaidi
 * paul90317
+* Fabian Albert (https://github.com/FAlbertDev)
 
 The approach is described in this paper
 > Oscar Reparaz, Josep Balasch and Ingrid Verbauwhede

--- a/src/dudect.h
+++ b/src/dudect.h
@@ -59,6 +59,11 @@
     For more information, please refer to <http://unlicense.org>
 */
 
+/* Used for improved C++ compatibility */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef DUDECT_IMPLEMENTATION
 
 #ifndef DUDECT_H_INCLUDED
@@ -467,3 +472,7 @@ int dudect_free(dudect_ctx_t *ctx)
 }
 
 #endif /* DUDECT_IMPLEMENTATION */
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif


### PR DESCRIPTION
- Rename variables named class into clazz
- Add explicit casts for calloc
- Remove spaces at line end (not C++ relevant)