### PR TITLE
Add `mfence` before issuing `rdtsc`

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -9,7 +9,7 @@ jobs:
       CC: gcc
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt install -y make gcc
+      - run: sudo apt-get update && sudo apt install -y make gcc
       - run: gcc --version
       - run: make CFLAGS="-g -fno-omit-frame-pointer -fsanitize=address" LDFLAGS="-fsanitize=address"
       # if timeouts (return code 124), consider it a success

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build
-        run: sudo apt-get install gcc-multilib g++-multilib && make -j
+        run: sudo apt-get update && sudo apt-get install gcc-multilib g++-multilib && make -j
 
   macos:
     runs-on: macos-latest
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build
-        run: sudo apt-get install gcc-multilib g++-multilib && make -j
+        run: sudo apt-get update && sudo apt-get install gcc-multilib g++-multilib && make -j
       # this is too flakey in github actions
       #- name: Run tests
       #  run: python3 test.py

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ dut_donnabad: $(OBJS_DONNABAD) examples/donnabad/dut_donnabad.c
 
 dut_simple: examples/simple/example.c
 	# higher compiler optimization levels can make this constant time
-	$(CC) $(LDFLAGS) -O0 $(INCS) -o dudect_simple_O0 examples/simple/example.c $(LIBS)
+	$(CC) $(LDFLAGS) -O0 $(INCS) -DMEASUREMENTS_PER_CHUNK=100000 -o dudect_simple_O0 examples/simple/example.c $(LIBS)
 	$(CC) $(LDFLAGS) -O2 $(INCS) -DMEASUREMENTS_PER_CHUNK=100000 -o dudect_simple_O2 examples/simple/example.c $(LIBS)
 
 .c.o:

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The following people have contributed to `dudect` through code, bug reports, iss
 * RashidAlsuwaidi
 * paul90317
 * Fabian Albert (https://github.com/FAlbertDev)
+* Anjan Roy (https://github.com/itzmeanjan)
 
 The approach is described in this paper
 > Oscar Reparaz, Josep Balasch and Ingrid Verbauwhede

--- a/examples/simple/example.c
+++ b/examples/simple/example.c
@@ -10,7 +10,7 @@ int check_tag(uint8_t *x, uint8_t *y, size_t len) {
   return memcmp(x, y, len);
 }
 
-#define SECRET_LEN_BYTES (16)
+#define SECRET_LEN_BYTES (512)
 
 uint8_t secret[SECRET_LEN_BYTES] = {0, 1, 2, 3, 4, 5, 6, 42};
 

--- a/src/dudect.h
+++ b/src/dudect.h
@@ -204,7 +204,6 @@ static int cmp(const int64_t *a, const int64_t *b) { return (int)(*a - *b); }
 
 static int64_t percentile(int64_t *a_sorted, double which, size_t size) {
   size_t array_position = (size_t)((double)size * (double)which);
-  assert(array_position >= 0);
   assert(array_position < size);
   return a_sorted[array_position];
 }

--- a/src/dudect.h
+++ b/src/dudect.h
@@ -268,6 +268,7 @@ uint8_t randombit(void) {
  To enforce CPU to issue RDTSC instruction where we want it to, we put a `mfence` instruction before
  issuing `rdtsc`, which should make all memory load/ store operations, prior to RDTSC, globally visible.
 
+ See https://github.com/oreparaz/dudect/issues/32
  See RDTSC documentation @ https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.htm#text=rdtsc&ig_expand=4395,5273
  See MFENCE documentation @ https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.htm#text=mfence&ig_expand=4395,5273,4395
 


### PR DESCRIPTION
Given the fact that a x86 CPU doesn't guarantee when it'll actually issue `RDTSC` instruction, if used in isolation, we *must* use it with a memory fence instruction such as `MFENCE` so that all memory load/ store operations, which appear before `RDTSC` instruction, in the program order (i.e. source code or compiler generated assembly), are globally visible. 

It's necessary to use a memory fence either `lfence` or `mfence` to enforce ordering constraints on CPU issuing `rdtsc` instruction. 

See 
- RDTSC without any ordering guarantees @ https://github.com/torvalds/linux/blob/9f8413c4a66f2fb776d3dc3c9ed20bf435eb305e/arch/x86/include/asm/msr.h#L171-L187 (**currently being used in this library**)
- RDTSC with *some* ordering guarantees https://github.com/torvalds/linux/blob/9f8413c4a66f2fb776d3dc3c9ed20bf435eb305e/arch/x86/include/asm/msr.h#L189-L223 (**this is where I'm proposing a transition to, a safer place**)

Note, I use `mfence` (serializes both load and stores) instead of `lfence` (serializes only loads), just to be safer. It shouldn't hurt. 
More about memory fencing @ https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.htm#text=fence&ig_expand=3977,4395,4395.